### PR TITLE
chat-space　非同期更新機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'coffee-rails', '~> 4.2'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes navigating your web application faster. Read more: https://github.com/turbolinks/turbolinks
-gem 'turbolinks', '~> 5'
+# gem 'turbolinks', '~> 5'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.5'
 # Use Redis adapter to run Action Cable in production

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,9 +221,6 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    turbolinks (5.2.1)
-      turbolinks-source (~> 5.2)
-    turbolinks-source (5.2.0)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     uglifier (4.2.0)
@@ -264,7 +261,6 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
-  turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,5 +12,4 @@
 //
 //= require jquery
 //= require jquery_ujs
-//= require turbolinks
 //= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -51,12 +51,14 @@ $(function(){
       processData: false,
       contentType: false
     })
+    .always(function(){
+      $('.new_message__btn').prop('disabled', false);
+    })
     .done(function(data){
       var html = buildHTML(data);
       $('.main__body').append(html);
       $('.main__body').animate({ scrollTop: $('.main__body')[0].scrollHeight});
       $('.new_message')[0].reset();
-      $('.new_message__btn').prop('disabled', false);
      })
      .fail(function() {
           alert("メッセージ送信に失敗しました");

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,65 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+          `<div class="main__body__text">
+            <div class="main__body__text__messages">
+              <div class="main__body__text__messages__name">
+                ${message.user_name}
+              </div>
+              <div class="main__body__text__messages__update">
+                ${message.created_at}
+              </div>
+            </div>
+            <div class="main__body__text__message">
+              <p class="main__body__text__message__content">
+              ${message.content}
+              </p>
+            </div>
+            <img src=${message.image} class="main__body__message__image">
+          </div>`
+      return html;
+    } else {
+      var html =
+          `<div class="main__body__text">
+            <div class="main__body__text__messages">
+              <div class="main__body__text__messages__name">
+                ${message.user_name}
+              </div>
+              <div class="main__body__text__messages__update">
+                ${message.created_at}
+              </div>
+            </div>
+            <div class="main__body__text__message">
+              <p class="main__body__text__message__content">
+                ${message.content}
+              </p>
+            </div>
+          </div>`
+      return html;
+    };
+  }
+  $("#new_message").on("submit", function(e){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: "json",
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+      $('.main__body').append(html);
+      $('.main__body').animate({ scrollTop: $('.main__body')[0].scrollHeight});
+      $('.new_message')[0].reset();
+      $('.new_message__btn').prop('disabled', false);
+     })
+     .fail(function() {
+          alert("メッセージ送信に失敗しました");
+      });
+})
+});

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -59,7 +59,7 @@ $(function(){
       $('.main__body').append(html);
       $('.main__body').animate({ scrollTop: $('.main__body')[0].scrollHeight});
       $('.new_message')[0].reset();
-     })
+    })
     .fail(function(){
       alert("メッセージ送信に失敗しました");
     });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -60,8 +60,8 @@ $(function(){
       $('.main__body').animate({ scrollTop: $('.main__body')[0].scrollHeight});
       $('.new_message')[0].reset();
      })
-     .fail(function() {
-          alert("メッセージ送信に失敗しました");
-      });
+    .fail(function(){
+      alert("メッセージ送信に失敗しました");
+    });
 })
 });

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -8,6 +8,10 @@
   display: flex;
 }
 
+a {
+  text-decoration: none;
+}
+
 .side {
   background-color: #253141;
   width: 300px;
@@ -34,12 +38,10 @@
         display: flex;
         &__edit {
           color: $white;
-          text-decoration: none;
         }
         &__cog {
           color: $white;
           margin-left: 5px;
-          text-decoration: none;
         }
       }
     }
@@ -48,6 +50,7 @@
     background-color: #2f3e51;
     height: calc(100vh - 100px);
     padding: 20px 20px 0 20px;
+    overflow: scroll;
     &__group {
       width: 100%;
       &__name {
@@ -68,7 +71,7 @@
 .main {
   background-color: $white;
   width: calc(100vw - 300px);
-  height: 100%;
+  height: 100vh;
   &__head {
     height: 100px;
     border-bottom: 1px solid #eee;
@@ -100,7 +103,6 @@
       line-height: 40px;
       text-align: center;
       &__btn {
-        text-decoration: none;
         color: $light_blue;
       }
     }
@@ -109,23 +111,27 @@
     background-color: #fafafa;
     height: calc(100vh - 190px);
     padding: 35px 45px;
+    overflow: scroll;
     &__text {
-      margin-bottom: 12px;
-      display: flex;
-      &__name {
-        color: #333;
-        font-size: 16px;
-        text-align: center;
+      padding-bottom: 40px;
+      &__messages {
+        margin-bottom: 12px;
+        display: flex;
+        &__name {
+          color: #333;
+          font-size: 16px;
+          text-align: center;
+        }
+        &__update {
+          color: $gray;
+          font-size: 12px;
+          padding: 0 10px;
+        }
       }
-      &__update {
-        color: $gray;
-        font-size: 12px;
-        padding: 0 10px;
+      &__message {
+        color: #434A54;
+        font-size: 14px;
       }
-    }
-    &__message {
-      color: #434A54;
-      font-size: 14px;
     }
   }
   &__foot {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,9 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,10 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
+    = stylesheet_link_tag    'application', media: 'all'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,8 +4,6 @@
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title ChatSpace
     = csrf_meta_tags
-    -# = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    -# = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
     = stylesheet_link_tag    'application', media: 'all'
     = javascript_include_tag 'application'
   %body

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,9 +1,10 @@
 .main__body__text
-  .main__body__text__name
-    = message.user.name
-  .main__body__text__update
-    = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
-.main__body__message
+  .main__body__text__messages
+    .main__body__text__messages__name
+      = message.user.name
+    .main__body__text__messages__update
+      = message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  .main__body__text__message
   - if message.content.present?
     %p.main__body__message__content
       = message.content

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,7 @@ Bundler.require(*Rails.groups)
 
 module ChatSpace
   class Application < Rails::Application
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
＃what
実装の動画：https://i.gyazo.com/4cc451998098a2bee359dc46a5761cb1.mp4
・chat-spaceのメッセージ送信機能を同期更新から非同期更新に更新しました。
・スクロール機能と、送信が連続でできる機能を実装しました。

＃why
非同期更新に変更することで、メッセージを送信するたびにブラウザを更新する処理を省くことができるため。