### PR TITLE
chat-space　自動更新機能実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,44 +1,57 @@
 $(function(){
-  function buildHTML(message) {
-    if ( message.image ) {
+  var buildHTML = function(message) {
+    if (message.content && message.image) {
       var html =
-          `<div class="main__body__text">
-            <div class="main__body__text__messages">
-              <div class="main__body__text__messages__name">
-                ${message.user_name}
-              </div>
-              <div class="main__body__text__messages__update">
-                ${message.created_at}
-              </div>
+        `<div class="main__body__text" data-message-id="${message.id}">
+          <div class="main__body__text__messages">
+            <div class="main__body__text__messages__name"> 
+              ${message.user_name}
             </div>
-            <div class="main__body__text__message">
-              <p class="main__body__text__message__content">
+            <div class="main__body__text__messages__update">
+              ${message.created_at}
+            </div>
+          </div>
+          <div class="main__body__text__message">
+            <p class="main__body__text__message__content">
               ${message.content}
-              </p>
-            </div>
-            <img src=${message.image} class="main__body__message__image">
-          </div>`
-      return html;
-    } else {
+            </p>
+          <img src="${message.image}" "class="main__body__message__image">
+          </div>
+        </div>`
+    } else if (message.content) {
       var html =
-          `<div class="main__body__text">
-            <div class="main__body__text__messages">
-              <div class="main__body__text__messages__name">
-                ${message.user_name}
-              </div>
-              <div class="main__body__text__messages__update">
-                ${message.created_at}
-              </div>
+        `<div class="main__body__text" data-message-id="${message.id}">
+          <div class="main__body__text__messages">
+            <div class="main__body__text__messages__name">
+              ${message.user_name}
             </div>
-            <div class="main__body__text__message">
-              <p class="main__body__text__message__content">
-                ${message.content}
-              </p>
+            <div class="main__body__text__messages__update">
+              ${message.created_at}
             </div>
-          </div>`
-      return html;
+          </div>
+          <div class="main__body__text__message">
+            <p class="main__body__text__message__content">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+    } else if (message.image) {
+      var html =
+        `<div class="main__body__text" data-message-id="${message.id}">
+          <div class="main__body__text__messages">
+            <div class="main__body__text__messages__name">
+              ${message.user_name}
+            </div>
+            <div class="main__body__text__messages__update">
+              ${message.created_at}
+            </div>
+          </div>
+          <img src="${message.image}" "class="main__body__message__image">
+        </div>`
     };
-  }
+    return html;
+  };
+  
   $("#new_message").on("submit", function(e) {
     e.preventDefault();
     var formData = new FormData(this);
@@ -63,5 +76,30 @@ $(function(){
     .fail(function() {
       alert("メッセージ送信に失敗しました");
     });
-})
+  });
+  var reloadMessages = function() {
+    var last_message_id = $('.main__body__text:last').data("message-id");
+    $.ajax({
+      url: "api/messages",
+      type: 'get',
+      dataType: 'json',
+      data: {id: last_message_id}
+    })
+    .done(function(messages) {
+      if (messages.length !== 0) {
+        var insertHTML = '';
+        $.each(messages, function(i, message) {
+          insertHTML += buildHTML(message)
+        });
+        $('.main__body').append(insertHTML);
+        $('.main__body').animate({scrollTop: $('.main__body')[0].scrollHeight});
+        }
+    })
+    .fail(function(){
+      alert('error');
+    });
+  };
+if (document.location.href.match(/\/groups\/\d+\/messages/)) {
+  setInterval(reloadMessages, 3000);
+}
 });

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessagesController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > ?", params[:id])
+  end
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main__body__text
+.main__body__text{"data-message-id": "#{message.id}"}
   .main__body__text__messages
     .main__body__text__messages__name
       = message.user.name

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.main__body__text{"data-message-id": "#{message.id}"}
+.main__body__text{data: {message: {id: message.id}}}
   .main__body__text__messages
     .main__body__text__messages__name
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,4 +1,5 @@
-json.user_name @message.user.name
-json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.content @message.content
 json.image @message.image_url
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.user_name @message.user.name
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
+    namespace :api do
+      resources :messages, only: :index, defaults: {format: 'json'}
+    end
   end
 end


### PR DESCRIPTION
#what
・message.js　自動更新機能のメソッドを追加。
・index.json.builder　jsonで受け取る値を定義。
・_message.html.haml　カスタムデータ型を追加。
・create.json.jbuilder　@message.idを追加。
・ルーティングにnamespaceを追加。
https://i.gyazo.com/4c3ec35c52a64524db5db230df164fe6.mp4
自動更新機能実装の動画です。

#why
ユーザー間でのメッセージのやりとりにおいて、一つ一つのメッセージを読み込んでいると非効率なため、自動更新機能を実装しました。
